### PR TITLE
2단계 - 로그인 리팩터링 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'com.sun.xml.bind:jaxb-impl:4.0.1'
     implementation 'com.sun.xml.bind:jaxb-core:4.0.1'
     implementation 'javax.xml.bind:jaxb-api:2.4.0-b180830.0359'
+    implementation 'org.springframework.security:spring-security-crypto:6.2.2'
     runtimeOnly 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.3.1'

--- a/src/main/java/roomescape/annotations/ValidationGroups.java
+++ b/src/main/java/roomescape/annotations/ValidationGroups.java
@@ -1,0 +1,6 @@
+package roomescape.annotations;
+
+public class ValidationGroups {
+    public interface NotBlankGroup {}
+    public interface PatternGroup {}
+}

--- a/src/main/java/roomescape/annotations/ValidationSequence.java
+++ b/src/main/java/roomescape/annotations/ValidationSequence.java
@@ -1,0 +1,9 @@
+package roomescape.annotations;
+
+import jakarta.validation.GroupSequence;
+import roomescape.annotations.ValidationGroups.NotBlankGroup;
+import roomescape.annotations.ValidationGroups.PatternGroup;
+
+@GroupSequence({NotBlankGroup.class, PatternGroup.class})
+public interface ValidationSequence {
+}

--- a/src/main/java/roomescape/config/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/config/LoginMemberArgumentResolver.java
@@ -1,0 +1,46 @@
+package roomescape.config;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+import roomescape.domain.LoginMember;
+import roomescape.domain.Member;
+import roomescape.service.MemberService;
+import roomescape.util.CookieUtils;
+import roomescape.util.JwtTokenProvider;
+
+import java.util.Objects;
+
+@Component
+public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberService memberService;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public LoginMemberArgumentResolver(MemberService memberService, JwtTokenProvider jwtTokenProvider) {
+        this.memberService = memberService;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterType().equals(LoginMember.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer
+            , NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        Cookie[] cookies = Objects.requireNonNull(webRequest.getNativeRequest(HttpServletRequest.class)).getCookies();
+        String token = CookieUtils.extractCookieValue(cookies, "token");
+
+        String email = jwtTokenProvider.getPayload(token);
+        Member member = memberService.findByEmail(email);
+
+        return new LoginMember(member.getId(), member.getEmail(), member.getName());
+    }
+}

--- a/src/main/java/roomescape/config/LoginMemberArgumentResolver.java
+++ b/src/main/java/roomescape/config/LoginMemberArgumentResolver.java
@@ -1,5 +1,6 @@
 package roomescape.config;
 
+import io.jsonwebtoken.Claims;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
@@ -9,21 +10,15 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 import roomescape.domain.LoginMember;
-import roomescape.domain.Member;
-import roomescape.service.MemberService;
 import roomescape.util.CookieUtils;
 import roomescape.util.JwtTokenProvider;
 
-import java.util.Objects;
-
 @Component
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
-
-    private final MemberService memberService;
+    private static final String TOKEN = "token";
     private final JwtTokenProvider jwtTokenProvider;
 
-    public LoginMemberArgumentResolver(MemberService memberService, JwtTokenProvider jwtTokenProvider) {
-        this.memberService = memberService;
+    public LoginMemberArgumentResolver(JwtTokenProvider jwtTokenProvider) {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
@@ -35,12 +30,15 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer
             , NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
-        Cookie[] cookies = Objects.requireNonNull(webRequest.getNativeRequest(HttpServletRequest.class)).getCookies();
-        String token = CookieUtils.extractCookieValue(cookies, "token");
+        HttpServletRequest httpServletRequest = webRequest.getNativeRequest(HttpServletRequest.class);
+        Cookie[] cookies = httpServletRequest == null ? null : httpServletRequest.getCookies();
 
-        String email = jwtTokenProvider.getPayload(token);
-        Member member = memberService.findByEmail(email);
+        String token = CookieUtils.extractCookieValue(cookies, TOKEN);
 
-        return new LoginMember(member.getId(), member.getEmail(), member.getName());
+        Claims body = jwtTokenProvider.getClaimsFromToken(token);
+        String email = jwtTokenProvider.getSubject(token);
+        String name = String.valueOf(body.get("name"));
+
+        return new LoginMember(email, name);
     }
 }

--- a/src/main/java/roomescape/config/SecurityConfig.java
+++ b/src/main/java/roomescape/config/SecurityConfig.java
@@ -1,0 +1,14 @@
+package roomescape.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+    @Bean
+    public PasswordEncoder getPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/roomescape/config/WebConfig.java
+++ b/src/main/java/roomescape/config/WebConfig.java
@@ -1,0 +1,22 @@
+package roomescape.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private final LoginMemberArgumentResolver loginMemberArgumentResolver;
+
+    public WebConfig(LoginMemberArgumentResolver loginMemberArgumentResolver) {
+        this.loginMemberArgumentResolver = loginMemberArgumentResolver;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginMemberArgumentResolver);
+    }
+}

--- a/src/main/java/roomescape/config/WebConfig.java
+++ b/src/main/java/roomescape/config/WebConfig.java
@@ -1,9 +1,6 @@
 package roomescape.config;
 
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 

--- a/src/main/java/roomescape/config/WebConfig.java
+++ b/src/main/java/roomescape/config/WebConfig.java
@@ -1,6 +1,9 @@
 package roomescape.config;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 

--- a/src/main/java/roomescape/controller/api/MemberController.java
+++ b/src/main/java/roomescape/controller/api/MemberController.java
@@ -1,6 +1,6 @@
 package roomescape.controller.api;
 
-import java.util.List;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -10,6 +10,8 @@ import org.springframework.web.bind.annotation.RestController;
 import roomescape.dto.request.MemberRequest;
 import roomescape.dto.response.MemberResponse;
 import roomescape.service.MemberService;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/members")
@@ -27,7 +29,7 @@ public class MemberController {
     }
 
     @PostMapping
-    public ResponseEntity<MemberResponse> signup(@RequestBody MemberRequest memberRequest) {
+    public ResponseEntity<MemberResponse> signup(@Valid @RequestBody MemberRequest memberRequest) {
         MemberResponse memberResponse = memberService.signup(memberRequest);
         return ResponseEntity.ok().body(memberResponse);
     }

--- a/src/main/java/roomescape/controller/api/MemberController.java
+++ b/src/main/java/roomescape/controller/api/MemberController.java
@@ -3,11 +3,16 @@ package roomescape.controller.api;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import roomescape.dto.request.MemberRequest;
 import roomescape.dto.response.MemberResponse;
 import roomescape.service.MemberService;
 
 @RestController
+@RequestMapping("/members")
 public class MemberController {
 
     private final MemberService memberService;
@@ -16,8 +21,14 @@ public class MemberController {
         this.memberService = memberService;
     }
 
-    @GetMapping("/members")
+    @GetMapping
     public ResponseEntity<List<MemberResponse>> findAllMembers() {
         return ResponseEntity.ok().body(memberService.findAllMembers());
+    }
+
+    @PostMapping
+    public ResponseEntity<MemberResponse> signup(@RequestBody MemberRequest memberRequest) {
+        MemberResponse memberResponse = memberService.signup(memberRequest);
+        return ResponseEntity.ok().body(memberResponse);
     }
 }

--- a/src/main/java/roomescape/controller/api/MemberController.java
+++ b/src/main/java/roomescape/controller/api/MemberController.java
@@ -1,0 +1,23 @@
+package roomescape.controller.api;
+
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import roomescape.dto.response.MemberResponse;
+import roomescape.service.MemberService;
+
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @GetMapping("/members")
+    public ResponseEntity<List<MemberResponse>> findAllMembers() {
+        return ResponseEntity.ok().body(memberService.findAllMembers());
+    }
+}

--- a/src/main/java/roomescape/controller/api/ReservationAdminController.java
+++ b/src/main/java/roomescape/controller/api/ReservationAdminController.java
@@ -1,5 +1,7 @@
 package roomescape.controller.api;
 
+import jakarta.validation.Valid;
+import java.net.URI;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -9,8 +11,6 @@ import roomescape.dto.request.ReservationAdminRequest;
 import roomescape.dto.response.ReservationResponse;
 import roomescape.service.MemberService;
 import roomescape.service.ReservationService;
-
-import java.net.URI;
 
 @RestController
 public class ReservationAdminController {
@@ -24,7 +24,7 @@ public class ReservationAdminController {
     }
 
     @PostMapping("/admin/reservations")
-    public ResponseEntity<ReservationResponse> createReservation(@RequestBody ReservationAdminRequest request) {
+    public ResponseEntity<ReservationResponse> createReservation(@Valid @RequestBody ReservationAdminRequest request) {
         Member member = memberService.findById(request.getMemberId());
 
         ReservationResponse reservation = reservationService.createAdminReservation(request, member);

--- a/src/main/java/roomescape/controller/api/ReservationAdminController.java
+++ b/src/main/java/roomescape/controller/api/ReservationAdminController.java
@@ -1,0 +1,35 @@
+package roomescape.controller.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import roomescape.domain.Member;
+import roomescape.dto.request.ReservationAdminRequest;
+import roomescape.dto.response.ReservationResponse;
+import roomescape.service.MemberService;
+import roomescape.service.ReservationService;
+
+import java.net.URI;
+
+@RestController
+public class ReservationAdminController {
+
+    private final ReservationService reservationService;
+    private final MemberService memberService;
+
+    public ReservationAdminController(ReservationService reservationService, MemberService memberService) {
+        this.reservationService = reservationService;
+        this.memberService = memberService;
+    }
+
+    @PostMapping("/admin/reservations")
+    public ResponseEntity<ReservationResponse> createReservation(@RequestBody ReservationAdminRequest request) {
+        Member member = memberService.findById(request.getMemberId());
+
+        ReservationResponse reservation = reservationService.createAdminReservation(request, member);
+        return ResponseEntity
+                .created(URI.create("/reservations/" + reservation.getId()))
+                .body(reservation);
+    }
+}

--- a/src/main/java/roomescape/controller/api/ReservationController.java
+++ b/src/main/java/roomescape/controller/api/ReservationController.java
@@ -2,8 +2,6 @@ package roomescape.controller.api;
 
 
 import jakarta.validation.Valid;
-import java.net.URI;
-import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,9 +10,13 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import roomescape.domain.LoginMember;
 import roomescape.dto.request.ReservationRequest;
 import roomescape.dto.response.ReservationResponse;
 import roomescape.service.ReservationService;
+
+import java.net.URI;
+import java.util.List;
 
 @RestController
 @RequestMapping("/reservations")
@@ -33,8 +35,9 @@ public class ReservationController {
     }
 
     @PostMapping
-    public ResponseEntity<ReservationResponse> createReservation(@RequestBody @Valid ReservationRequest request) {
-        ReservationResponse newReservation = reservationService.createReservation(request);
+    public ResponseEntity<ReservationResponse> createReservation(@RequestBody @Valid ReservationRequest request,
+                                                                 LoginMember loginMember) {
+        ReservationResponse newReservation = reservationService.createReservation(request, loginMember);
 
         return ResponseEntity
                 .created(URI.create("/reservations/" + newReservation.getId()))

--- a/src/main/java/roomescape/controller/api/ReservationController.java
+++ b/src/main/java/roomescape/controller/api/ReservationController.java
@@ -1,8 +1,10 @@
 package roomescape.controller.api;
 
 
-import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,13 +12,11 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import roomescape.annotations.ValidationSequence;
 import roomescape.domain.LoginMember;
 import roomescape.dto.request.ReservationRequest;
 import roomescape.dto.response.ReservationResponse;
 import roomescape.service.ReservationService;
-
-import java.net.URI;
-import java.util.List;
 
 @RestController
 @RequestMapping("/reservations")
@@ -35,8 +35,9 @@ public class ReservationController {
     }
 
     @PostMapping
-    public ResponseEntity<ReservationResponse> createReservation(@RequestBody @Valid ReservationRequest request,
-                                                                 LoginMember loginMember) {
+    public ResponseEntity<ReservationResponse> createReservation(
+            @RequestBody @Validated(ValidationSequence.class) ReservationRequest request,
+            LoginMember loginMember) {
         ReservationResponse newReservation = reservationService.createReservation(request, loginMember);
 
         return ResponseEntity

--- a/src/main/java/roomescape/controller/api/ReservationTimeController.java
+++ b/src/main/java/roomescape/controller/api/ReservationTimeController.java
@@ -1,7 +1,9 @@
 package roomescape.controller.api;
 
-import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,12 +12,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import roomescape.annotations.ValidationSequence;
 import roomescape.dto.request.ReservationTimeRequest;
 import roomescape.dto.response.ReservationTimeResponse;
 import roomescape.service.ReservationTimeService;
-
-import java.net.URI;
-import java.util.List;
 
 @RestController
 @RequestMapping("/times")
@@ -29,7 +29,7 @@ public class ReservationTimeController {
 
     @PostMapping
     public ResponseEntity<ReservationTimeResponse> createReservationTime(
-            @Valid @RequestBody ReservationTimeRequest reservationTimeRequest) {
+            @Validated(ValidationSequence.class) @RequestBody ReservationTimeRequest reservationTimeRequest) {
         ReservationTimeResponse newReservationTime = reservationTimeService.createReservationTime(
                 reservationTimeRequest);
 

--- a/src/main/java/roomescape/controller/front/ReservationAdminViewController.java
+++ b/src/main/java/roomescape/controller/front/ReservationAdminViewController.java
@@ -1,13 +1,31 @@
 package roomescape.controller.front;
 
 
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+import roomescape.domain.Member;
+import roomescape.dto.request.ReservationAdminRequest;
+import roomescape.dto.response.ReservationResponse;
+import roomescape.service.MemberService;
+import roomescape.service.ReservationService;
 
 @RequestMapping("/admin")
 @Controller
 public class ReservationAdminViewController {
+
+    private final ReservationService reservationService;
+    private final MemberService memberService;
+
+    public ReservationAdminViewController(ReservationService reservationService, MemberService memberService) {
+        this.reservationService = reservationService;
+        this.memberService = memberService;
+    }
 
     @GetMapping
     public String index() {
@@ -27,5 +45,16 @@ public class ReservationAdminViewController {
     @GetMapping("/theme")
     public String theme() {
         return "admin/theme";
+    }
+
+    @PostMapping("/reservations")
+    @ResponseBody
+    public ResponseEntity<ReservationResponse> createReservation(@RequestBody ReservationAdminRequest request) {
+        Member member = memberService.findById(request.getMemberId());
+
+        ReservationResponse reservation = reservationService.createAdminReservation(request, member);
+        return ResponseEntity
+                .created(URI.create("/reservations/" + reservation.getId()))
+                .body(reservation);
     }
 }

--- a/src/main/java/roomescape/controller/front/ReservationAdminViewController.java
+++ b/src/main/java/roomescape/controller/front/ReservationAdminViewController.java
@@ -1,31 +1,13 @@
 package roomescape.controller.front;
 
 
-import java.net.URI;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseBody;
-import roomescape.domain.Member;
-import roomescape.dto.request.ReservationAdminRequest;
-import roomescape.dto.response.ReservationResponse;
-import roomescape.service.MemberService;
-import roomescape.service.ReservationService;
 
 @RequestMapping("/admin")
 @Controller
 public class ReservationAdminViewController {
-
-    private final ReservationService reservationService;
-    private final MemberService memberService;
-
-    public ReservationAdminViewController(ReservationService reservationService, MemberService memberService) {
-        this.reservationService = reservationService;
-        this.memberService = memberService;
-    }
 
     @GetMapping
     public String index() {
@@ -47,14 +29,5 @@ public class ReservationAdminViewController {
         return "admin/theme";
     }
 
-    @PostMapping("/reservations")
-    @ResponseBody
-    public ResponseEntity<ReservationResponse> createReservation(@RequestBody ReservationAdminRequest request) {
-        Member member = memberService.findById(request.getMemberId());
 
-        ReservationResponse reservation = reservationService.createAdminReservation(request, member);
-        return ResponseEntity
-                .created(URI.create("/reservations/" + reservation.getId()))
-                .body(reservation);
-    }
 }

--- a/src/main/java/roomescape/controller/front/ReservationViewController.java
+++ b/src/main/java/roomescape/controller/front/ReservationViewController.java
@@ -15,4 +15,9 @@ public class ReservationViewController {
     public String login() {
         return "/login";
     }
+
+    @GetMapping("/signup")
+    public String signup() {
+        return "/signup";
+    }
 }

--- a/src/main/java/roomescape/domain/LoginMember.java
+++ b/src/main/java/roomescape/domain/LoginMember.java
@@ -2,6 +2,7 @@ package roomescape.domain;
 
 public class LoginMember {
 
+
     private Long id;
     private String email;
     private String name;

--- a/src/main/java/roomescape/domain/LoginMember.java
+++ b/src/main/java/roomescape/domain/LoginMember.java
@@ -1,0 +1,27 @@
+package roomescape.domain;
+
+public class LoginMember {
+
+    private Long id;
+    private String email;
+    private String name;
+
+
+    public LoginMember(Long id, String email, String name) {
+        this.id = id;
+        this.email = email;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/roomescape/domain/LoginMember.java
+++ b/src/main/java/roomescape/domain/LoginMember.java
@@ -1,15 +1,11 @@
 package roomescape.domain;
 
 public class LoginMember {
-
-
     private Long id;
     private String email;
     private String name;
 
-
-    public LoginMember(Long id, String email, String name) {
-        this.id = id;
+    public LoginMember(String email, String name) {
         this.email = email;
         this.name = name;
     }

--- a/src/main/java/roomescape/domain/Member.java
+++ b/src/main/java/roomescape/domain/Member.java
@@ -1,8 +1,6 @@
 package roomescape.domain;
 
 import java.util.Objects;
-import org.thymeleaf.util.StringUtils;
-import roomescape.exception.custom.PasswordMismatchException;
 
 public class Member {
 
@@ -64,11 +62,5 @@ public class Member {
     @Override
     public int hashCode() {
         return Objects.hash(id);
-    }
-
-    public void checkPassword(String password) {
-        if (!StringUtils.equals(this.password, password)) {
-            throw new PasswordMismatchException();
-        }
     }
 }

--- a/src/main/java/roomescape/domain/Member.java
+++ b/src/main/java/roomescape/domain/Member.java
@@ -1,8 +1,8 @@
 package roomescape.domain;
 
-import org.thymeleaf.util.StringUtils;
-
 import java.util.Objects;
+import org.thymeleaf.util.StringUtils;
+import roomescape.exception.custom.PasswordMismatchException;
 
 public class Member {
 
@@ -36,8 +36,12 @@ public class Member {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
         Member member = (Member) o;
         return Objects.equals(id, member.id);
     }
@@ -47,7 +51,9 @@ public class Member {
         return Objects.hash(id);
     }
 
-    public boolean checkPassword(String password) {
-        return StringUtils.equals(this.password, password);
+    public void checkPassword(String password) {
+        if (!StringUtils.equals(this.password, password)) {
+            throw new PasswordMismatchException();
+        }
     }
 }

--- a/src/main/java/roomescape/domain/Member.java
+++ b/src/main/java/roomescape/domain/Member.java
@@ -18,6 +18,11 @@ public class Member {
         this.password = password;
     }
 
+    public Member(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/roomescape/domain/Member.java
+++ b/src/main/java/roomescape/domain/Member.java
@@ -18,6 +18,10 @@ public class Member {
         this.password = password;
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public String getName() {
         return name;
     }

--- a/src/main/java/roomescape/domain/Member.java
+++ b/src/main/java/roomescape/domain/Member.java
@@ -23,6 +23,12 @@ public class Member {
         this.name = name;
     }
 
+    public Member(String name, String email, String password) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/roomescape/dto/request/LoginRequest.java
+++ b/src/main/java/roomescape/dto/request/LoginRequest.java
@@ -1,10 +1,12 @@
 package roomescape.dto.request;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 
 public class LoginRequest {
 
     @NotBlank(message = "이메일은 필수 값입니다.")
+    @Email
     private String email;
 
     @NotBlank(message = "비밀번호는 필수 값입니다.")

--- a/src/main/java/roomescape/dto/request/MemberRequest.java
+++ b/src/main/java/roomescape/dto/request/MemberRequest.java
@@ -1,9 +1,16 @@
 package roomescape.dto.request;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
 public class MemberRequest {
-    // TODO. 값 체크 필요
+
+    @NotBlank(message = "이름은 필수 값입니다.")
     private String name;
+    @NotBlank(message = "이메일은 필수 값입니다.")
+    @Email
     private String email;
+    @NotBlank(message = "비밀번호는 필수 값입니다.")
     private String password;
 
     public MemberRequest() {

--- a/src/main/java/roomescape/dto/request/MemberRequest.java
+++ b/src/main/java/roomescape/dto/request/MemberRequest.java
@@ -1,0 +1,29 @@
+package roomescape.dto.request;
+
+public class MemberRequest {
+    // TODO. 값 체크 필요
+    private String name;
+    private String email;
+    private String password;
+
+    public MemberRequest() {
+    }
+
+    public MemberRequest(String name, String email, String password) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+}

--- a/src/main/java/roomescape/dto/request/ReservationAdminRequest.java
+++ b/src/main/java/roomescape/dto/request/ReservationAdminRequest.java
@@ -1,10 +1,15 @@
 package roomescape.dto.request;
 
-public class ReservationAdminRequest {
+import jakarta.validation.constraints.NotBlank;
 
+public class ReservationAdminRequest {
+    @NotBlank(message = "날짜가 입력되지 않았습니다.")
     private String date;
+    @NotBlank(message = "테마가 선택되지 않았습니다.")
     private Long themeId;
+    @NotBlank(message = "예약 시간이 선택되지 않았습니다.")
     private Long timeId;
+    @NotBlank(message = "회원이 선택되지 않았습니다.")
     private Long memberId;
 
     public ReservationAdminRequest() {

--- a/src/main/java/roomescape/dto/request/ReservationAdminRequest.java
+++ b/src/main/java/roomescape/dto/request/ReservationAdminRequest.java
@@ -1,15 +1,19 @@
 package roomescape.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 public class ReservationAdminRequest {
     @NotBlank(message = "날짜가 입력되지 않았습니다.")
     private String date;
-    @NotBlank(message = "테마가 선택되지 않았습니다.")
+
+    @NotNull(message = "테마가 선택되지 않았습니다.")
     private Long themeId;
-    @NotBlank(message = "예약 시간이 선택되지 않았습니다.")
+
+    @NotNull(message = "예약 시간이 선택되지 않았습니다.")
     private Long timeId;
-    @NotBlank(message = "회원이 선택되지 않았습니다.")
+
+    @NotNull(message = "회원이 선택되지 않았습니다.")
     private Long memberId;
 
     public ReservationAdminRequest() {

--- a/src/main/java/roomescape/dto/request/ReservationAdminRequest.java
+++ b/src/main/java/roomescape/dto/request/ReservationAdminRequest.java
@@ -1,0 +1,36 @@
+package roomescape.dto.request;
+
+public class ReservationAdminRequest {
+
+    private String date;
+    private Long themeId;
+    private Long timeId;
+    private Long memberId;
+
+    public ReservationAdminRequest() {
+
+    }
+
+    public ReservationAdminRequest(String date, Long themeId, Long timeId, Long memberId) {
+        this.date = date;
+        this.themeId = themeId;
+        this.timeId = timeId;
+        this.memberId = memberId;
+    }
+
+    public String getDate() {
+        return date;
+    }
+
+    public Long getThemeId() {
+        return themeId;
+    }
+
+    public Long getTimeId() {
+        return timeId;
+    }
+
+    public Long getMemberId() {
+        return memberId;
+    }
+}

--- a/src/main/java/roomescape/dto/request/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/request/ReservationRequest.java
@@ -1,46 +1,39 @@
 package roomescape.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 public class ReservationRequest {
-
-//    @NotBlank(message = "예약자명은 필수 값입니다.")
-//    private String name;
 
     @NotBlank(message = "날짜는 필수 값입니다.")
     @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "yyyy-MM-dd 형식이 아닙니다.")
     private String date;
 
-    @NotBlank(message = "예약하려면 시간을 선택해야합니다. 확인 후 다시 시도해주세요.")
-    private String timeId;
+    @NotNull(message = "예약하려면 시간을 선택해야합니다. 확인 후 다시 시도해주세요.")
+    private Long timeId;
 
-    @NotBlank(message = "예약하려면 테마를 선택해야합니다. 확인 후 다시 시도해주세요.")
-    private String themeId;
+    @NotNull(message = "예약하려면 테마를 선택해야합니다. 확인 후 다시 시도해주세요.")
+    private Long themeId;
 
     public ReservationRequest() {
     }
 
-    public ReservationRequest(String date, String timeId, String themeId) {
-//        this.name = name;
+    public ReservationRequest(String date, Long timeId, Long themeId) {
         this.date = date;
         this.timeId = timeId;
         this.themeId = themeId;
     }
 
-//    public String getName() {
-//        return name;
-//    }
-
     public String getDate() {
         return date;
     }
 
-    public String getTimeId() {
+    public Long getTimeId() {
         return timeId;
     }
 
-    public String getThemeId() {
+    public Long getThemeId() {
         return themeId;
     }
 }

--- a/src/main/java/roomescape/dto/request/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/request/ReservationRequest.java
@@ -3,11 +3,15 @@ package roomescape.dto.request;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import roomescape.annotations.ValidationGroups.NotBlankGroup;
+import roomescape.annotations.ValidationGroups.PatternGroup;
 
 public class ReservationRequest {
 
-    @NotBlank(message = "날짜는 필수 값입니다.")
-    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "yyyy-MM-dd 형식이 아닙니다.")
+    @NotBlank(message = "날짜는 필수 값입니다.", groups = NotBlankGroup.class)
+    @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$"
+            , message = "yyyy-MM-dd 형식이 아닙니다."
+            , groups = PatternGroup.class)
     private String date;
 
     @NotNull(message = "예약하려면 시간을 선택해야합니다. 확인 후 다시 시도해주세요.")

--- a/src/main/java/roomescape/dto/request/ReservationRequest.java
+++ b/src/main/java/roomescape/dto/request/ReservationRequest.java
@@ -5,8 +5,8 @@ import jakarta.validation.constraints.Pattern;
 
 public class ReservationRequest {
 
-    @NotBlank(message = "예약자명은 필수 값입니다.")
-    private String name;
+//    @NotBlank(message = "예약자명은 필수 값입니다.")
+//    private String name;
 
     @NotBlank(message = "날짜는 필수 값입니다.")
     @Pattern(regexp = "^\\d{4}-\\d{2}-\\d{2}$", message = "yyyy-MM-dd 형식이 아닙니다.")
@@ -21,16 +21,16 @@ public class ReservationRequest {
     public ReservationRequest() {
     }
 
-    public ReservationRequest(String name, String date, String timeId, String themeId) {
-        this.name = name;
+    public ReservationRequest(String date, String timeId, String themeId) {
+//        this.name = name;
         this.date = date;
         this.timeId = timeId;
         this.themeId = themeId;
     }
 
-    public String getName() {
-        return name;
-    }
+//    public String getName() {
+//        return name;
+//    }
 
     public String getDate() {
         return date;

--- a/src/main/java/roomescape/dto/request/ReservationTimeRequest.java
+++ b/src/main/java/roomescape/dto/request/ReservationTimeRequest.java
@@ -2,11 +2,15 @@ package roomescape.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import roomescape.annotations.ValidationGroups.NotBlankGroup;
+import roomescape.annotations.ValidationGroups.PatternGroup;
 
 public class ReservationTimeRequest {
 
-    @NotBlank(message = "시간은 필수 값입니다.")
-    @Pattern(regexp = "^([01]?[0-9]|2[0-3]):[0-5][0-9]$", message = "HH:mm 형식이 아닙니다.")
+    @NotBlank(message = "시간은 필수 값입니다.", groups = NotBlankGroup.class)
+    @Pattern(regexp = "^([01]?[0-9]|2[0-3]):[0-5][0-9]$"
+            , message = "HH:mm 형식이 아닙니다."
+            , groups = PatternGroup.class)
     private String startAt;
 
     public ReservationTimeRequest() {

--- a/src/main/java/roomescape/dto/response/MemberResponse.java
+++ b/src/main/java/roomescape/dto/response/MemberResponse.java
@@ -1,0 +1,20 @@
+package roomescape.dto.response;
+
+public class MemberResponse {
+
+    private Long id;
+    private String name;
+
+    public MemberResponse(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/main/java/roomescape/exception/custom/DuplicateMemberException.java
+++ b/src/main/java/roomescape/exception/custom/DuplicateMemberException.java
@@ -1,0 +1,16 @@
+package roomescape.exception.custom;
+
+import org.springframework.http.HttpStatus;
+
+public class DuplicateMemberException extends BusinessException {
+    private static final String MESSAGE = "동일한 아이디가 존재합니다.";
+
+    public DuplicateMemberException() {
+        super(MESSAGE, HttpStatus.CONFLICT);
+    }
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return super.getHttpStatus();
+    }
+}

--- a/src/main/java/roomescape/exception/custom/ExistingReservationException.java
+++ b/src/main/java/roomescape/exception/custom/ExistingReservationException.java
@@ -3,7 +3,7 @@ package roomescape.exception.custom;
 import org.springframework.http.HttpStatus;
 
 public class ExistingReservationException extends BusinessException {
-    private static final String MESSAGE = "이미 지나간 날짜는 예약할 수 없습니다.";
+    private static final String MESSAGE = "동일한 예약이 존재합니다.";
 
     public ExistingReservationException() {
         super(MESSAGE, HttpStatus.CONFLICT);

--- a/src/main/java/roomescape/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package roomescape.exception.handler;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -9,6 +10,7 @@ import roomescape.exception.dto.ErrorResponse;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
+    private static final String INTERNAL_SERVER_ERROR_MESSAGE = "예상치 못한 오류가 발생했습니다.";
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
@@ -27,5 +29,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
         return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(
+                new ErrorResponse(INTERNAL_SERVER_ERROR_MESSAGE));
     }
 }

--- a/src/main/java/roomescape/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/roomescape/exception/handler/GlobalExceptionHandler.java
@@ -23,4 +23,9 @@ public class GlobalExceptionHandler {
         return ResponseEntity.status(e.getHttpStatus())
                 .body(new ErrorResponse(e.getMessage()));
     }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        return ResponseEntity.badRequest().body(new ErrorResponse(e.getMessage()));
+    }
 }

--- a/src/main/java/roomescape/repository/MemberDao.java
+++ b/src/main/java/roomescape/repository/MemberDao.java
@@ -1,5 +1,8 @@
 package roomescape.repository;
 
+import java.util.List;
+import java.util.Optional;
+import javax.sql.DataSource;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
@@ -7,9 +10,6 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 import org.springframework.stereotype.Repository;
 import roomescape.domain.Member;
-
-import javax.sql.DataSource;
-import java.util.Optional;
 
 @Repository
 public class MemberDao {
@@ -48,5 +48,31 @@ public class MemberDao {
         }
 
         return Optional.ofNullable(member);
+    }
+
+    public Optional<Member> findById(Long id) {
+        final String sql = "SELECT id, name, email, password FROM member where id = ?";
+
+        Member member;
+        try {
+            member = jdbcTemplate.queryForObject(sql,
+                    (rs, rowNum) -> new Member(
+                            rs.getLong("id")
+                            , rs.getString("name")
+                            , rs.getString("email")
+                            , rs.getString("password")
+                    ), id);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+
+        return Optional.ofNullable(member);
+    }
+
+    public List<Member> findAllMembers() {
+        final String sql = "select id, name from member";
+        return jdbcTemplate.query(sql, (rs, rowNum) -> new Member(
+                rs.getLong("id"),
+                rs.getString("name")));
     }
 }

--- a/src/main/java/roomescape/repository/ReservationDao.java
+++ b/src/main/java/roomescape/repository/ReservationDao.java
@@ -1,5 +1,7 @@
 package roomescape.repository;
 
+import java.util.List;
+import javax.sql.DataSource;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
@@ -8,9 +10,6 @@ import org.springframework.stereotype.Repository;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationTheme;
 import roomescape.domain.ReservationTime;
-
-import javax.sql.DataSource;
-import java.util.List;
 
 @Repository
 public class ReservationDao {
@@ -78,7 +77,7 @@ public class ReservationDao {
         jdbcTemplate.update(sql, id);
     }
 
-    public Long countByDateAndTimeIdAndThemeId(String date, String timeId, String themeId) {
+    public Long countByDateAndTimeIdAndThemeId(String date, Long timeId, Long themeId) {
         final String sql = """
                     SELECT count(*) 
                     FROM reservation r 

--- a/src/main/java/roomescape/service/MemberService.java
+++ b/src/main/java/roomescape/service/MemberService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.thymeleaf.util.StringUtils;
 import roomescape.domain.Member;
 import roomescape.dto.request.LoginRequest;
+import roomescape.dto.request.MemberRequest;
 import roomescape.dto.response.LoginResponse;
 import roomescape.dto.response.MemberResponse;
 import roomescape.exception.custom.TokenNotFoundException;
@@ -67,5 +68,20 @@ public class MemberService {
             throw new TokenNotFoundException();
         }
         jwtTokenProvider.validateToken(token);
+    }
+
+    public MemberResponse signup(MemberRequest memberRequest) {
+        // TODO. 중복체크 필요
+        // TODO. 비밀번호 암호화 필요
+        Member member = memberDao.save(this.convertToEntity(memberRequest));
+        return this.convertToResponse(member);
+    }
+
+    private Member convertToEntity(MemberRequest request) {
+        return new Member(request.getName(), request.getEmail(), request.getPassword());
+    }
+
+    private MemberResponse convertToResponse(Member member) {
+        return new MemberResponse(member.getId(), member.getName());
     }
 }

--- a/src/main/java/roomescape/service/MemberService.java
+++ b/src/main/java/roomescape/service/MemberService.java
@@ -78,7 +78,6 @@ public class MemberService {
         if (StringUtils.isEmpty(token)) {
             throw new TokenNotFoundException();
         }
-        jwtTokenProvider.validateToken(token);
     }
 
     public MemberResponse signup(MemberRequest memberRequest) {

--- a/src/main/java/roomescape/service/MemberService.java
+++ b/src/main/java/roomescape/service/MemberService.java
@@ -5,7 +5,6 @@ import org.thymeleaf.util.StringUtils;
 import roomescape.domain.Member;
 import roomescape.dto.request.LoginRequest;
 import roomescape.dto.response.LoginResponse;
-import roomescape.exception.custom.PasswordMismatchException;
 import roomescape.exception.custom.TokenNotFoundException;
 import roomescape.exception.custom.UserNotFoundException;
 import roomescape.repository.MemberDao;
@@ -32,10 +31,7 @@ public class MemberService {
 
     private void validateMemberCredentials(String email, String password) {
         Member member = findByEmail(email);
-
-        if (!member.checkPassword(password)) {
-            throw new PasswordMismatchException();
-        }
+        member.checkPassword(password);
     }
 
     private Member findByEmail(String email) {

--- a/src/main/java/roomescape/service/MemberService.java
+++ b/src/main/java/roomescape/service/MemberService.java
@@ -34,7 +34,7 @@ public class MemberService {
         member.checkPassword(password);
     }
 
-    private Member findByEmail(String email) {
+    public Member findByEmail(String email) {
         return memberDao.findByEmail(email)
                 .orElseThrow(UserNotFoundException::new);
     }

--- a/src/main/java/roomescape/service/MemberService.java
+++ b/src/main/java/roomescape/service/MemberService.java
@@ -1,10 +1,12 @@
 package roomescape.service;
 
+import java.util.List;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.util.StringUtils;
 import roomescape.domain.Member;
 import roomescape.dto.request.LoginRequest;
 import roomescape.dto.response.LoginResponse;
+import roomescape.dto.response.MemberResponse;
 import roomescape.exception.custom.TokenNotFoundException;
 import roomescape.exception.custom.UserNotFoundException;
 import roomescape.repository.MemberDao;
@@ -37,6 +39,18 @@ public class MemberService {
     public Member findByEmail(String email) {
         return memberDao.findByEmail(email)
                 .orElseThrow(UserNotFoundException::new);
+    }
+
+    public Member findById(Long id) {
+        return memberDao.findById(id)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    public List<MemberResponse> findAllMembers() {
+        List<Member> members = memberDao.findAllMembers();
+        return members.stream()
+                .map(member -> new MemberResponse(member.getId(), member.getName()))
+                .toList();
     }
 
     public LoginResponse loginCheck(String token) {

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -1,10 +1,7 @@
 package roomescape.service;
 
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
 import org.springframework.stereotype.Service;
+import roomescape.domain.LoginMember;
 import roomescape.domain.Reservation;
 import roomescape.domain.ReservationTheme;
 import roomescape.domain.ReservationTime;
@@ -17,6 +14,11 @@ import roomescape.exception.custom.PastDateReservationException;
 import roomescape.repository.ReservationDao;
 import roomescape.repository.ReservationThemeDao;
 import roomescape.repository.ReservationTimeDao;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 
 @Service
 public class ReservationService {
@@ -32,10 +34,10 @@ public class ReservationService {
         this.reservationThemeDao = reservationThemeDao;
     }
 
-    public ReservationResponse createReservation(ReservationRequest reservationRequest) {
+    public ReservationResponse createReservation(ReservationRequest reservationRequest, LoginMember loginMember) {
         validateReservationCreation(reservationRequest);
 
-        Reservation reservation = reservationDao.save(this.convertToEntity(reservationRequest));
+        Reservation reservation = reservationDao.save(this.convertToEntity(reservationRequest, loginMember));
         return this.convertToResponse(reservation);
     }
 
@@ -71,12 +73,14 @@ public class ReservationService {
                 reservation.getTime().getStartAt(), reservation.getTheme().getName());
     }
 
-    private Reservation convertToEntity(ReservationRequest reservationRequest) {
+    private Reservation convertToEntity(ReservationRequest reservationRequest, LoginMember loginMember) {
         ReservationTime reservationTime = findReservationTimeById(reservationRequest.getTimeId());
         ReservationTheme reservationTheme = findReservationThemeById(reservationRequest.getThemeId());
 
-        return new Reservation(reservationRequest.getName(), reservationRequest.getDate(), reservationTime,
-                reservationTheme);
+        return new Reservation(loginMember.getName()
+                , reservationRequest.getDate()
+                , reservationTime
+                , reservationTheme);
     }
 
     private ReservationTime findReservationTimeById(String timeId) {

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -52,7 +52,6 @@ public class ReservationService {
         return this.convertToResponse(reservation);
     }
 
-
     public List<ReservationResponse> findAllReservations() {
         return reservationDao.findAll().stream()
                 .map(this::convertToResponse)

--- a/src/main/java/roomescape/service/ReservationService.java
+++ b/src/main/java/roomescape/service/ReservationService.java
@@ -44,8 +44,8 @@ public class ReservationService {
 
     public ReservationResponse createAdminReservation(ReservationAdminRequest request, Member member) {
         ReservationRequest reservationRequest = new ReservationRequest(request.getDate()
-                , String.valueOf(request.getTimeId())
-                , String.valueOf(request.getThemeId()));
+                , request.getTimeId()
+                , request.getThemeId());
         validateReservationCreation(reservationRequest);
 
         Reservation reservation = reservationDao.save(this.convertToEntity(reservationRequest, member.getName()));
@@ -94,15 +94,15 @@ public class ReservationService {
                 , reservationTheme);
     }
 
-    private ReservationTime findReservationTimeById(String timeId) {
+    private ReservationTime findReservationTimeById(Long timeId) {
         return reservationTimeDao
-                .findById(Long.parseLong(timeId))
+                .findById(timeId)
                 .orElseThrow(InvalidReservationTimeException::new);
     }
 
-    private ReservationTheme findReservationThemeById(String themeId) {
+    private ReservationTheme findReservationThemeById(Long themeId) {
         return reservationThemeDao
-                .findById(Long.parseLong(themeId))
+                .findById(themeId)
                 .orElseThrow(InvalidReservationThemeException::new);
     }
 

--- a/src/main/java/roomescape/util/CookieUtils.java
+++ b/src/main/java/roomescape/util/CookieUtils.java
@@ -2,6 +2,7 @@ package roomescape.util;
 
 import jakarta.servlet.http.Cookie;
 import org.springframework.http.ResponseCookie;
+import org.springframework.util.StringUtils;
 
 public class CookieUtils {
 
@@ -18,14 +19,26 @@ public class CookieUtils {
     }
 
     public static String extractCookieValue(Cookie[] cookies, String cookieName) {
-        if (cookies != null) {
-            for (Cookie cookie : cookies) {
-                if (cookieName.equals(cookie.getName())) {
-                    return cookie.getValue();
-                }
+        validateCookies(cookies, cookieName);
+
+        String cookieValue = "";
+        for (Cookie cookie : cookies) {
+            if (cookieName.equals(cookie.getName())) {
+                cookieValue = cookie.getValue();
+                break;
             }
         }
-        return null;
+        return cookieValue;
+    }
+
+    private static void validateCookies(Cookie[] cookies, String cookieName) {
+        if (cookies == null) {
+            throw new IllegalArgumentException("쿠키가 존재하지 않습니다.");
+        }
+
+        if (StringUtils.isEmpty(cookieName)) {
+            throw new IllegalArgumentException("쿠키명이 올바르지 않습니다.");
+        }
     }
 
     public static Cookie expireCookieByName(Cookie[] cookies, String name) {

--- a/src/main/java/roomescape/util/JwtTokenProvider.java
+++ b/src/main/java/roomescape/util/JwtTokenProvider.java
@@ -34,10 +34,11 @@ public class JwtTokenProvider {
     }
 
     public String getSubject(String token) {
+        validateToken(token);
         return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
     }
 
-    public void validateToken(String token) {
+    private void validateToken(String token) {
         Jws<Claims> claims;
         try {
             claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
@@ -51,6 +52,7 @@ public class JwtTokenProvider {
     }
 
     public Claims getClaimsFromToken(String token) {
+        validateToken(token);
         return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody();
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,1 +1,0 @@
-INSERT INTO member (id, name, email, password) VALUES (1, '테스트', 'test@email.com', '1234');

--- a/src/main/resources/static/js/reservation-with-member.js
+++ b/src/main/resources/static/js/reservation-with-member.js
@@ -27,10 +27,10 @@ function render(data) {
     const row = tableBody.insertRow();
 
     row.insertCell(0).textContent = item.id;              // 예약 id
-    row.insertCell(1).textContent = item.member.name;     // 사용자 name
-    row.insertCell(2).textContent = item.theme.name;      // 테마 name
+    row.insertCell(1).textContent = item.name;     // 사용자 name
+    row.insertCell(2).textContent = item.themeName;      // 테마 name
     row.insertCell(3).textContent = item.date;            // date
-    row.insertCell(4).textContent = item.time.startAt;    // 예약 시간 startAt
+    row.insertCell(4).textContent = item.timeStartAt;    // 예약 시간 startAt
 
     const actionCell = row.insertCell(row.cells.length);
     actionCell.appendChild(createActionButton('삭제', 'btn-danger', deleteRow));

--- a/src/main/resources/static/js/user-reservation.js
+++ b/src/main/resources/static/js/user-reservation.js
@@ -140,14 +140,12 @@ function onReservationButtonClick() {
   const selectedDate = document.getElementById("datepicker").value;
   const selectedThemeId = document.querySelector('.theme-slot.active')?.getAttribute('data-theme-id');
   const selectedTimeId = document.querySelector('.time-slot.active')?.getAttribute('data-time-id');
-  const name = document.getElementById('user-name').value;
 
   if (selectedDate && selectedThemeId && selectedTimeId) {
     const reservationData = {
       date: selectedDate,
       themeId: selectedThemeId,
-      timeId: selectedTimeId,
-      name: name
+      timeId: selectedTimeId
     };
 
     fetch('/reservations', {

--- a/src/main/resources/static/js/user-scripts.js
+++ b/src/main/resources/static/js/user-scripts.js
@@ -136,9 +136,6 @@ function register(event) {
         // 에러 처리
         console.error('Error during signup:', error);
       });
-
-  // 폼 제출에 의한 페이지 리로드 방지
-  event.preventDefault();
 }
 
 function base64DecodeUnicode(str) {

--- a/src/main/resources/templates/admin/reservation.html
+++ b/src/main/resources/templates/admin/reservation.html
@@ -72,12 +72,7 @@
 </div>
 
 <script src="/js/user-scripts.js"></script>
-
-<!--
-  TODO: [2단계] 예약 생성 기능 변경 - 관리자
-        reservation.js 파일 대신 reservation-with-member.js 파일 사용
--->
 <script src="/js/reservation-with-time-and-theme.js"></script>
-<!--<script src="/js/reservation-with-member.js"></script>-->
+<script src="/js/reservation-with-member.js"></script>
 </body>
 </html>

--- a/src/main/resources/templates/reservation.html
+++ b/src/main/resources/templates/reservation.html
@@ -75,16 +75,6 @@
         </div>
     </div>
 
-    <!--
-    TODO: [2단계] 예약 생성 기능 변경 - 사용자
-          적용 후 아래에 있는 User Name Input 삭제
-    -->
-    <!-- User Name Input -->
-    <div class="input-group mb-3 mt-4">
-        <span class="input-group-text" id="name">예약자명</span>
-        <input id="user-name" type="text" class="form-control" aria-label="Username" aria-describedby="name">
-    </div>
-
     <!-- Reservation Button -->
     <div class="button-group float-right">
         <button id="reserve-button" class="btn btn-primary mt-3 disabled">예약하기</button>

--- a/src/main/resources/templates/signup.html
+++ b/src/main/resources/templates/signup.html
@@ -58,7 +58,7 @@
       <label for="name">Name</label>
       <input type="name" class="form-control" id="name" placeholder="Enter name">
     </div>
-    <button type="submit" class="btn btn-custom" onclick="register()">Register</button>
+    <button type="button" class="btn btn-custom" onclick="register()">Register</button>
   </form>
 </div>
 

--- a/src/test/java/roomescape/controller/AuthTest.java
+++ b/src/test/java/roomescape/controller/AuthTest.java
@@ -1,5 +1,9 @@
 package roomescape.controller;
 
+import static org.hamcrest.Matchers.is;
+import static roomescape.fixture.AuthFixture.사용자_로그인;
+import static roomescape.fixture.MemberFixture.회원가입;
+
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,10 +14,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import roomescape.dto.request.LoginRequest;
-
-import static org.hamcrest.Matchers.is;
-import static roomescape.fixture.AuthFixture.사용자_로그인;
-import static roomescape.fixture.MemberFixture.회원가입;
 
 @DisplayName("인증 관련 테스트")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)

--- a/src/test/java/roomescape/controller/AuthTest.java
+++ b/src/test/java/roomescape/controller/AuthTest.java
@@ -2,6 +2,7 @@ package roomescape.controller;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -12,6 +13,7 @@ import roomescape.dto.request.LoginRequest;
 
 import static org.hamcrest.Matchers.is;
 import static roomescape.fixture.AuthFixture.사용자_로그인;
+import static roomescape.fixture.MemberFixture.회원가입;
 
 @DisplayName("인증 관련 테스트")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -22,6 +24,11 @@ public class AuthTest {
     public static final String TOKEN_COOKIE_NAME = "token";
     public static final String NAME = "테스트";
 
+    @BeforeEach
+    void init() {
+        회원가입(EMAIL, PASSWORD, NAME);
+    }
+
     @DisplayName("[로그인] - 유효한 자격 증명으로 로그인하여 토큰을 획득한다.")
     @Test
     void login() {
@@ -31,7 +38,6 @@ public class AuthTest {
                 .statusCode(HttpStatus.OK.value())
                 .cookie(TOKEN_COOKIE_NAME);
     }
-
 
 
     @DisplayName("[로그인] - 아이디 또는 비밀번호를 입력하지 않은 경우 에러가 발생한다.")

--- a/src/test/java/roomescape/controller/AuthTest.java
+++ b/src/test/java/roomescape/controller/AuthTest.java
@@ -14,6 +14,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import roomescape.dto.request.LoginRequest;
+import roomescape.exception.custom.PasswordMismatchException;
+import roomescape.exception.custom.TokenNotFoundException;
 
 @DisplayName("인증 관련 테스트")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -43,6 +45,8 @@ public class AuthTest {
     @DisplayName("[로그인] - 아이디 또는 비밀번호를 입력하지 않은 경우 에러가 발생한다.")
     @Test
     void loginRequiredValueException() {
+        String message = "비밀번호는 필수 값입니다.";
+
         RestAssured
                 .given().log().all()
                 .body(new LoginRequest(EMAIL, ""))
@@ -50,12 +54,15 @@ public class AuthTest {
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().post("/login")
                 .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is(message));
     }
 
     @DisplayName("[로그인] - 아이디(이메일) 또는 비밀번호가 일치하지 않는 경우 에러가 발생한다.")
     @Test
     void loginMismatchValueException() {
+        String message = new PasswordMismatchException().getMessage();
+
         RestAssured
                 .given().log().all()
                 .body(new LoginRequest(EMAIL, "12345"))
@@ -63,7 +70,8 @@ public class AuthTest {
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().post("/login")
                 .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is(message));
     }
 
     @DisplayName("[로그인 체크] - 유효한 토큰으로 로그인 사용자의 인증정보를 조회한다")
@@ -94,6 +102,8 @@ public class AuthTest {
     @DisplayName("[로그인 체크] - 올바르지 않은 쿠키인 경우 로그인 체크시 에러가 발생한다.")
     @Test
     void loginCheckIncorrectTokenException() {
+        String message = new TokenNotFoundException().getMessage();
+
         RestAssured
                 .given().log().all()
                 .cookie(TOKEN_COOKIE_NAME, "")
@@ -101,6 +111,7 @@ public class AuthTest {
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/login/check")
                 .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is(message));
     }
 }

--- a/src/test/java/roomescape/controller/AuthTest.java
+++ b/src/test/java/roomescape/controller/AuthTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.annotation.DirtiesContext;
 import roomescape.dto.request.LoginRequest;
 
 import static org.hamcrest.Matchers.is;
+import static roomescape.fixture.AuthFixture.사용자_로그인;
 
 @DisplayName("인증 관련 테스트")
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
@@ -24,17 +25,14 @@ public class AuthTest {
     @DisplayName("[로그인] - 유효한 자격 증명으로 로그인하여 토큰을 획득한다.")
     @Test
     void login() {
-        Response response = RestAssured
-                .given().log().all()
-                .body(new LoginRequest(EMAIL, PASSWORD))
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when().post("/login");
+        Response response = 사용자_로그인(EMAIL, PASSWORD);
 
         response.then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .cookie(TOKEN_COOKIE_NAME);
     }
+
+
 
     @DisplayName("[로그인] - 아이디 또는 비밀번호를 입력하지 않은 경우 에러가 발생한다.")
     @Test

--- a/src/test/java/roomescape/controller/MemberTest.java
+++ b/src/test/java/roomescape/controller/MemberTest.java
@@ -1,5 +1,8 @@
 package roomescape.controller;
 
+import static org.hamcrest.Matchers.is;
+import static roomescape.fixture.MemberFixture.회원가입;
+
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
@@ -8,9 +11,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
-
-import static org.hamcrest.Matchers.is;
-import static roomescape.fixture.MemberFixture.회원가입;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)

--- a/src/test/java/roomescape/controller/MemberTest.java
+++ b/src/test/java/roomescape/controller/MemberTest.java
@@ -1,0 +1,36 @@
+package roomescape.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@DisplayName("사용자 테스트")
+public class MemberTest {
+
+    @Test
+    @DisplayName("회원가입 테스트")
+    void signup() {
+
+    }
+
+    @Test
+    @DisplayName("회원가입 시 중복된 아이디가 있는 경우 에러가 발생한다.")
+    void signupDuplicateId() {
+
+    }
+
+    @Test
+    @DisplayName("회원가입 시 올바르지 않은 값인 경우 에러가 발생한다.")
+    void signupIncorrectValue() {
+
+    }
+
+    @Test
+    @DisplayName("모든 회원 정보를 조회한다.(아이디, 이름)")
+    void findAllMembers() {
+
+    }
+}

--- a/src/test/java/roomescape/controller/MemberTest.java
+++ b/src/test/java/roomescape/controller/MemberTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.exception.custom.DuplicateMemberException;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -37,8 +38,10 @@ public class MemberTest {
 
         Response response = 회원가입(EMAIL, PASSWORD, NAME);
 
+        String message = new DuplicateMemberException().getMessage();
         response.then().log().all()
-                .statusCode(HttpStatus.CONFLICT.value());
+                .statusCode(HttpStatus.CONFLICT.value())
+                .body("message", is(message));
     }
 
     @Test
@@ -46,8 +49,10 @@ public class MemberTest {
     void signupIncorrectValue() {
         Response response = 회원가입("", PASSWORD, NAME);
 
+        String message = "이메일은 필수 값입니다.";
         response.then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is(message));
     }
 
     @Test

--- a/src/test/java/roomescape/controller/MemberTest.java
+++ b/src/test/java/roomescape/controller/MemberTest.java
@@ -1,36 +1,68 @@
 package roomescape.controller;
 
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+
+import static org.hamcrest.Matchers.is;
+import static roomescape.fixture.MemberFixture.회원가입;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @DisplayName("사용자 테스트")
 public class MemberTest {
 
+    private static final String EMAIL = "test@email.com";
+    private static final String PASSWORD = "1234";
+    private static final String NAME = "테스트";
+
     @Test
     @DisplayName("회원가입 테스트")
     void signup() {
+        Response response = 회원가입(EMAIL, PASSWORD, NAME);
 
+        response.then().log().all()
+                .statusCode(HttpStatus.OK.value());
     }
 
     @Test
     @DisplayName("회원가입 시 중복된 아이디가 있는 경우 에러가 발생한다.")
     void signupDuplicateId() {
+        회원가입(EMAIL, PASSWORD, NAME);
 
+        Response response = 회원가입(EMAIL, PASSWORD, NAME);
+
+        response.then().log().all()
+                .statusCode(HttpStatus.CONFLICT.value());
     }
 
     @Test
     @DisplayName("회원가입 시 올바르지 않은 값인 경우 에러가 발생한다.")
     void signupIncorrectValue() {
+        Response response = 회원가입("", PASSWORD, NAME);
 
+        response.then().log().all()
+                .statusCode(HttpStatus.BAD_REQUEST.value());
     }
 
     @Test
     @DisplayName("모든 회원 정보를 조회한다.(아이디, 이름)")
     void findAllMembers() {
+        for (int i = 0; i < 5; i++) {
+            회원가입("test" + i + "@email.com", PASSWORD, NAME);
+        }
 
+        RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/members")
+                .then().log().all()
+                .body("size()", is(5));
     }
 }

--- a/src/test/java/roomescape/controller/ReservationTest.java
+++ b/src/test/java/roomescape/controller/ReservationTest.java
@@ -19,6 +19,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.exception.custom.ExistingReservationException;
+import roomescape.exception.custom.InvalidReservationThemeException;
+import roomescape.exception.custom.InvalidReservationTimeException;
+import roomescape.exception.custom.PastDateReservationException;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -70,16 +74,18 @@ public class ReservationTest {
     void createReservationIsDateExpired() {
         Map<String, Object> params = new HashMap<>();
         params.put("date", "2023-08-05");
-        params.put("timeId", "1");
-        params.put("themeId", "1");
+        params.put("timeId", 1L);
+        params.put("themeId", 1L);
 
+        String message = new PastDateReservationException().getMessage();
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .cookie("token", token)
                 .body(params)
                 .when().post("/reservations")
                 .then().log().all()
-                .statusCode(HttpStatus.UNPROCESSABLE_ENTITY.value());
+                .statusCode(HttpStatus.UNPROCESSABLE_ENTITY.value())
+                .body("message", is(message));
     }
 
     @Test
@@ -87,16 +93,18 @@ public class ReservationTest {
     void createReservationException() {
         Map<String, Object> params = new HashMap<>();
         params.put("date", "");
-        params.put("timeId", "1");
-        params.put("themeId", "1");
+        params.put("timeId", 1L);
+        params.put("themeId", 1L);
 
+        String message = "날짜는 필수 값입니다.";
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .cookie("token", token)
                 .body(params)
                 .when().post("/reservations")
                 .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is(message));
     }
 
     @Test
@@ -104,16 +112,18 @@ public class ReservationTest {
     void createReservationDateException() {
         Map<String, Object> params = new HashMap<>();
         params.put("date", "2023-kk-05");
-        params.put("timeId", "1");
-        params.put("themeId", "1");
+        params.put("timeId", 1L);
+        params.put("themeId", 1L);
 
+        String message = "yyyy-MM-dd 형식이 아닙니다.";
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .cookie("token", token)
                 .body(params)
                 .when().post("/reservations")
                 .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is(message));
     }
 
     @Test
@@ -121,16 +131,18 @@ public class ReservationTest {
     void createReservationEmptyTimeId() {
         Map<String, Object> params = new HashMap<>();
         params.put("date", "2024-06-25");
-        params.put("timeId", "3");
-        params.put("themeId", "1");
+        params.put("timeId", 3L);
+        params.put("themeId", 1L);
 
+        String message = new InvalidReservationTimeException().getMessage();
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .cookie("token", token)
                 .body(params)
                 .when().post("/reservations")
                 .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is(message));
     }
 
     @Test
@@ -138,16 +150,18 @@ public class ReservationTest {
     void createReservationEmptyThemeId() {
         Map<String, Object> params = new HashMap<>();
         params.put("date", "2024-06-25");
-        params.put("timeId", "1");
-        params.put("themeId", "3");
+        params.put("timeId", 1L);
+        params.put("themeId", 3L);
 
+        String message = new InvalidReservationThemeException().getMessage();
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .cookie("token", token)
                 .body(params)
                 .when().post("/reservations")
                 .then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is(message));
     }
 
     @Test
@@ -155,8 +169,8 @@ public class ReservationTest {
     void createReservationDateAndTimeStartAtDuplicate() {
         Map<String, Object> params = new HashMap<>();
         params.put("date", "2024-06-25");
-        params.put("timeId", "1");
-        params.put("themeId", "1");
+        params.put("timeId", 1L);
+        params.put("themeId", 1L);
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
@@ -166,13 +180,15 @@ public class ReservationTest {
                 .then().log().all()
                 .statusCode(HttpStatus.CREATED.value());
 
+        String message = new ExistingReservationException().getMessage();
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .cookie("token", token)
                 .body(params)
                 .when().post("/reservations")
                 .then().log().all()
-                .statusCode(HttpStatus.CONFLICT.value());
+                .statusCode(HttpStatus.CONFLICT.value())
+                .body("message", is(message));
     }
 
     @Test
@@ -180,8 +196,8 @@ public class ReservationTest {
     void findAllReservations() {
         Map<String, Object> params = new HashMap<>();
         params.put("date", "2024-06-25");
-        params.put("timeId", "1");
-        params.put("themeId", "1");
+        params.put("timeId", 1L);
+        params.put("themeId", 1L);
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
@@ -221,7 +237,7 @@ public class ReservationTest {
         params.put("date", "2024-06-25");
         params.put("timeId", 1L);
         params.put("themeId", 1L);
-        params.put("memberId", "1");
+        params.put("memberId", 1L);
 
         Response response = 예약을_생성한다_관리자(params, token);
 

--- a/src/test/java/roomescape/controller/ReservationTest.java
+++ b/src/test/java/roomescape/controller/ReservationTest.java
@@ -3,6 +3,7 @@ package roomescape.controller;
 import static org.hamcrest.Matchers.is;
 import static roomescape.fixture.AuthFixture.사용자_로그인;
 import static roomescape.fixture.ReservationFixture.예약을_생성한다;
+import static roomescape.fixture.ReservationFixture.예약을_생성한다_관리자;
 import static roomescape.fixture.ReservationThemeFixture.예약테마를_생성한다;
 import static roomescape.fixture.ReservationTimeFixture.예약시간을_생성한다;
 
@@ -207,5 +208,22 @@ public class ReservationTest {
                 .then().log().all()
                 .statusCode(HttpStatus.OK.value())
                 .body("size()", is(0));
+    }
+
+    @Test
+    @DisplayName("예약을 생성한다. (관리자)")
+    void createAdminReservation() {
+        Map<String, String> params = new HashMap<>();
+        params.put("date", "2024-06-25");
+        params.put("timeId", "1");
+        params.put("themeId", "1");
+        params.put("memberId", "1");
+
+        Response response = 예약을_생성한다_관리자(params, token);
+
+        int expectedIdValue = 1;
+        response.then().log().all()
+                .statusCode(HttpStatus.CREATED.value())
+                .body("id", is(expectedIdValue));
     }
 }

--- a/src/test/java/roomescape/controller/ReservationTest.java
+++ b/src/test/java/roomescape/controller/ReservationTest.java
@@ -31,7 +31,7 @@ public class ReservationTest {
 
     @BeforeEach
     void init() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("startAt", "15:40");
 
         예약시간을_생성한다(params);
@@ -52,10 +52,10 @@ public class ReservationTest {
     @Test
     @DisplayName("예약을 생성한다.")
     void createReservation() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("date", "2024-06-25");
-        params.put("timeId", "1");
-        params.put("themeId", "1");
+        params.put("timeId", 1L);
+        params.put("themeId", 1L);
 
         Response response = 예약을_생성한다(params, token);
 
@@ -68,7 +68,7 @@ public class ReservationTest {
     @Test
     @DisplayName("예약을 생성할 때 이미 지난 날짜인경우 에러가 발생한다.")
     void createReservationIsDateExpired() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("date", "2023-08-05");
         params.put("timeId", "1");
         params.put("themeId", "1");
@@ -85,7 +85,7 @@ public class ReservationTest {
     @Test
     @DisplayName("예약을 생성할 때 필수값이 없으면 에러가 발생한다.")
     void createReservationException() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("date", "");
         params.put("timeId", "1");
         params.put("themeId", "1");
@@ -102,7 +102,7 @@ public class ReservationTest {
     @Test
     @DisplayName("예약을 생성할때 유효하지 않은 날짜를 입력하면 에러가 발생한다.")
     void createReservationDateException() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("date", "2023-kk-05");
         params.put("timeId", "1");
         params.put("themeId", "1");
@@ -119,7 +119,7 @@ public class ReservationTest {
     @Test
     @DisplayName("예약을 생성할때 존재하지 않는 예약시간 아이디를 입력하면 에러가 발생한다.")
     void createReservationEmptyTimeId() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("date", "2024-06-25");
         params.put("timeId", "3");
         params.put("themeId", "1");
@@ -136,7 +136,7 @@ public class ReservationTest {
     @Test
     @DisplayName("예약을 생성할때 존재하지 않는 예약테마 아이디를 입력하면 에러가 발생한다.")
     void createReservationEmptyThemeId() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("date", "2024-06-25");
         params.put("timeId", "1");
         params.put("themeId", "3");
@@ -153,7 +153,7 @@ public class ReservationTest {
     @Test
     @DisplayName("예약을 생성할 때 중복된 날짜 및 시간인 경우 에러가 발생한다.")
     void createReservationDateAndTimeStartAtDuplicate() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("date", "2024-06-25");
         params.put("timeId", "1");
         params.put("themeId", "1");
@@ -178,7 +178,7 @@ public class ReservationTest {
     @Test
     @DisplayName("예약 목록을 조회한다.")
     void findAllReservations() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("date", "2024-06-25");
         params.put("timeId", "1");
         params.put("themeId", "1");
@@ -217,10 +217,10 @@ public class ReservationTest {
     @Test
     @DisplayName("예약을 생성한다. (관리자)")
     void createAdminReservation() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("date", "2024-06-25");
-        params.put("timeId", "1");
-        params.put("themeId", "1");
+        params.put("timeId", 1L);
+        params.put("themeId", 1L);
         params.put("memberId", "1");
 
         Response response = 예약을_생성한다_관리자(params, token);

--- a/src/test/java/roomescape/controller/ReservationTest.java
+++ b/src/test/java/roomescape/controller/ReservationTest.java
@@ -2,6 +2,7 @@ package roomescape.controller;
 
 import static org.hamcrest.Matchers.is;
 import static roomescape.fixture.AuthFixture.사용자_로그인;
+import static roomescape.fixture.MemberFixture.회원가입;
 import static roomescape.fixture.ReservationFixture.예약을_생성한다;
 import static roomescape.fixture.ReservationFixture.예약을_생성한다_관리자;
 import static roomescape.fixture.ReservationThemeFixture.예약테마를_생성한다;
@@ -25,6 +26,7 @@ import org.springframework.test.annotation.DirtiesContext;
 public class ReservationTest {
     private static final String EMAIL = "test@email.com";
     private static final String PASSWORD = "1234";
+    private static final String NAME = "테스트";
     private String token;
 
     @BeforeEach
@@ -40,6 +42,8 @@ public class ReservationTest {
         params.put("thumbnail", "https://i.pinimg.com/236x/6e/bc/46/6ebc461a94a49f9ea3b8bbe2204145d4.jpg");
 
         예약테마를_생성한다(params);
+
+        회원가입(EMAIL, PASSWORD, NAME);
 
         Response response = 사용자_로그인(EMAIL, PASSWORD);
         token = response.getCookie("token");

--- a/src/test/java/roomescape/controller/ReservationThemeTest.java
+++ b/src/test/java/roomescape/controller/ReservationThemeTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.exception.custom.DuplicateThemeException;
+import roomescape.exception.custom.ReservationThemeConflictException;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -68,8 +70,10 @@ public class ReservationThemeTest {
 
         Response response = 예약테마를_생성한다(params);
 
+        String message = "테마이름은 필수 값입니다.";
         response.then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is(message));
     }
 
     @Test
@@ -87,8 +91,10 @@ public class ReservationThemeTest {
 
         Response secondCreateResponse = 예약테마를_생성한다(params);
 
+        String message = new DuplicateThemeException().getMessage();
         secondCreateResponse.then().log().all()
-                .statusCode(HttpStatus.CONFLICT.value());
+                .statusCode(HttpStatus.CONFLICT.value())
+                .body("message", is(message));
     }
 
     @Test
@@ -146,15 +152,17 @@ public class ReservationThemeTest {
         params.clear();
         params.put("name", "브라운");
         params.put("date", "2024-06-25");
-        params.put("timeId", "1");
-        params.put("themeId", "1");
+        params.put("timeId", 1L);
+        params.put("themeId", 1L);
         예약을_생성한다(params, token);
 
+        String message = new ReservationThemeConflictException().getMessage();
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(params)
                 .when().delete("/themes/1")
                 .then().log().all()
-                .statusCode(HttpStatus.CONFLICT.value());
+                .statusCode(HttpStatus.CONFLICT.value())
+                .body("message", is(message));
     }
 }

--- a/src/test/java/roomescape/controller/ReservationThemeTest.java
+++ b/src/test/java/roomescape/controller/ReservationThemeTest.java
@@ -1,6 +1,7 @@
 package roomescape.controller;
 
 import static org.hamcrest.Matchers.is;
+import static roomescape.fixture.AuthFixture.사용자_로그인;
 import static roomescape.fixture.ReservationFixture.예약을_생성한다;
 import static roomescape.fixture.ReservationThemeFixture.예약테마를_생성한다;
 import static roomescape.fixture.ReservationTimeFixture.예약시간을_생성한다;
@@ -10,6 +11,8 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -24,6 +27,16 @@ public class ReservationThemeTest {
     private final String NAME = "레벨2 탈출";
     private final String DESCRIPTION = "우테코 레벨2를 탈출하는 내용입니다.";
     private final String THUMBNAIL = "https://i.pinimg.com/236x/6e/bc/46/6ebc461a94a49f9ea3b8bbe2204145d4.jpg";
+
+    private static final String EMAIL = "test@email.com";
+    private static final String PASSWORD = "1234";
+    private String token;
+
+    @BeforeEach
+    void init() {
+        Response response = 사용자_로그인(EMAIL, PASSWORD);
+        token = response.getCookie("token");
+    }
 
     @Test
     @DisplayName("예약테마를 생성한다.")
@@ -132,7 +145,7 @@ public class ReservationThemeTest {
         params.put("date", "2024-06-25");
         params.put("timeId", "1");
         params.put("themeId", "1");
-        예약을_생성한다(params);
+        예약을_생성한다(params, token);
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)

--- a/src/test/java/roomescape/controller/ReservationThemeTest.java
+++ b/src/test/java/roomescape/controller/ReservationThemeTest.java
@@ -2,6 +2,7 @@ package roomescape.controller;
 
 import static org.hamcrest.Matchers.is;
 import static roomescape.fixture.AuthFixture.사용자_로그인;
+import static roomescape.fixture.MemberFixture.회원가입;
 import static roomescape.fixture.ReservationFixture.예약을_생성한다;
 import static roomescape.fixture.ReservationThemeFixture.예약테마를_생성한다;
 import static roomescape.fixture.ReservationTimeFixture.예약시간을_생성한다;
@@ -29,11 +30,14 @@ public class ReservationThemeTest {
     private final String THUMBNAIL = "https://i.pinimg.com/236x/6e/bc/46/6ebc461a94a49f9ea3b8bbe2204145d4.jpg";
 
     private static final String EMAIL = "test@email.com";
+    private static final String MEMBER_NAME = "테스트";
     private static final String PASSWORD = "1234";
     private String token;
 
     @BeforeEach
     void init() {
+        회원가입(EMAIL, PASSWORD, MEMBER_NAME);
+
         Response response = 사용자_로그인(EMAIL, PASSWORD);
         token = response.getCookie("token");
     }

--- a/src/test/java/roomescape/controller/ReservationThemeTest.java
+++ b/src/test/java/roomescape/controller/ReservationThemeTest.java
@@ -12,7 +12,6 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -45,7 +44,7 @@ public class ReservationThemeTest {
     @Test
     @DisplayName("예약테마를 생성한다.")
     void createReservationTheme() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", NAME);
         params.put("description", DESCRIPTION);
         params.put("thumbnail", THUMBNAIL);
@@ -62,7 +61,7 @@ public class ReservationThemeTest {
     @Test
     @DisplayName("예약테마를 생성할 때 필수값이 없는 경우 에러가 발생한다.")
     void missingRequiredFieldsThrowsErrorOnThemeCreation() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", "");
         params.put("description", DESCRIPTION);
         params.put("thumbnail", THUMBNAIL);
@@ -76,7 +75,7 @@ public class ReservationThemeTest {
     @Test
     @DisplayName("예약테마를 생성할 때 테마이름이 중복인 경우 에러가 발생한다.")
     void createReservationThemeDuplicate() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", NAME);
         params.put("description", DESCRIPTION);
         params.put("thumbnail", THUMBNAIL);
@@ -95,7 +94,7 @@ public class ReservationThemeTest {
     @Test
     @DisplayName("예약테마 목록을 조회한다.")
     void findAllReservationThemes() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", NAME);
         params.put("description", DESCRIPTION);
         params.put("thumbnail", THUMBNAIL);
@@ -114,7 +113,7 @@ public class ReservationThemeTest {
     @Test
     @DisplayName("예약테마를 삭제한다.")
     void deleteReservationTheme() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", NAME);
         params.put("description", DESCRIPTION);
         params.put("thumbnail", THUMBNAIL);
@@ -132,7 +131,7 @@ public class ReservationThemeTest {
     @Test
     @DisplayName("예약테마를 삭제할 때 사용중인 예약이 있는 경우 에러가 발생한다.")
     void deleteReservationThemeExistReservation() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", NAME);
         params.put("description", DESCRIPTION);
         params.put("thumbnail", THUMBNAIL);

--- a/src/test/java/roomescape/controller/ReservationTimeTest.java
+++ b/src/test/java/roomescape/controller/ReservationTimeTest.java
@@ -2,6 +2,7 @@ package roomescape.controller;
 
 import static org.hamcrest.Matchers.is;
 import static roomescape.fixture.AuthFixture.사용자_로그인;
+import static roomescape.fixture.MemberFixture.회원가입;
 import static roomescape.fixture.ReservationFixture.예약을_생성한다;
 import static roomescape.fixture.ReservationThemeFixture.예약테마를_생성한다;
 import static roomescape.fixture.ReservationTimeFixture.예약시간을_생성한다;
@@ -26,10 +27,13 @@ public class ReservationTimeTest {
 
     private static final String EMAIL = "test@email.com";
     private static final String PASSWORD = "1234";
+    private static final String NAME = "테스트";
     private String token;
 
     @BeforeEach
     void init() {
+        회원가입(EMAIL, PASSWORD, NAME);
+
         Response response = 사용자_로그인(EMAIL, PASSWORD);
         token = response.getCookie("token");
     }

--- a/src/test/java/roomescape/controller/ReservationTimeTest.java
+++ b/src/test/java/roomescape/controller/ReservationTimeTest.java
@@ -18,6 +18,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.annotation.DirtiesContext;
+import roomescape.exception.custom.DuplicateTimeException;
+import roomescape.exception.custom.ReservationTimeConflictException;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
@@ -55,9 +57,11 @@ public class ReservationTimeTest {
         Map<String, Object> params = new HashMap<>();
         params.put("startAt", "");
 
+        String message = "시간은 필수 값입니다.";
         Response response = 예약시간을_생성한다(params);
         response.then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is(message));
     }
 
     @Test
@@ -66,9 +70,11 @@ public class ReservationTimeTest {
         Map<String, Object> params = new HashMap<>();
         params.put("startAt", "kk:12");
 
+        String message = "HH:mm 형식이 아닙니다.";
         Response response = 예약시간을_생성한다(params);
         response.then().log().all()
-                .statusCode(HttpStatus.BAD_REQUEST.value());
+                .statusCode(HttpStatus.BAD_REQUEST.value())
+                .body("message", is(message));
     }
 
     @Test
@@ -82,9 +88,11 @@ public class ReservationTimeTest {
                 .statusCode(HttpStatus.CREATED.value())
                 .body("id", is(1));
 
+        String message = new DuplicateTimeException().getMessage();
         Response secondCreateResponse = 예약시간을_생성한다(params);
         secondCreateResponse.then().log().all()
-                .statusCode(HttpStatus.CONFLICT.value());
+                .statusCode(HttpStatus.CONFLICT.value())
+                .body("message", is(message));
     }
 
     @Test
@@ -142,12 +150,14 @@ public class ReservationTimeTest {
         params.put("themeId", 1L);
         예약을_생성한다(params, token);
 
+        String message = new ReservationTimeConflictException().getMessage();
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(params)
                 .when().delete("/times/1")
                 .then().log().all()
-                .statusCode(HttpStatus.CONFLICT.value());
+                .statusCode(HttpStatus.CONFLICT.value())
+                .body("message", is(message));
     }
 
     @DisplayName("테마의 예약가능 시간 목록을 조회한다.")

--- a/src/test/java/roomescape/controller/ReservationTimeTest.java
+++ b/src/test/java/roomescape/controller/ReservationTimeTest.java
@@ -12,7 +12,6 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import java.util.HashMap;
 import java.util.Map;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,7 +40,7 @@ public class ReservationTimeTest {
     @Test
     @DisplayName("예약시간을 생성한다.")
     void createReservationTime() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("startAt", "10:00");
 
         Response response = 예약시간을_생성한다(params);
@@ -53,7 +52,7 @@ public class ReservationTimeTest {
     @Test
     @DisplayName("예약시간을 생성할 때 필수값이 없으면 에러가 발생한다.")
     void missingRequiredFieldsThrowsErrorOnTimeCreation() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("startAt", "");
 
         Response response = 예약시간을_생성한다(params);
@@ -64,7 +63,7 @@ public class ReservationTimeTest {
     @Test
     @DisplayName("예약시간을 생성할 때 유효하지 않은 값을 입력하면 에러가 발생한다.")
     void invalidTimeThrowsErrorOnTimeCreation() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("startAt", "kk:12");
 
         Response response = 예약시간을_생성한다(params);
@@ -75,7 +74,7 @@ public class ReservationTimeTest {
     @Test
     @DisplayName("예약시간을 생성할 때 시간이 중복되면 에러가 발생한다.")
     void createReservationTimeDuplicate() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("startAt", "10:00");
 
         Response firstCreateResponse = 예약시간을_생성한다(params);
@@ -91,7 +90,7 @@ public class ReservationTimeTest {
     @Test
     @DisplayName("예약시간 목록을 조회한다.")
     void findAllReservationTimes() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("startAt", "10:00");
 
         예약시간을_생성한다(params);
@@ -108,7 +107,7 @@ public class ReservationTimeTest {
     @Test
     @DisplayName("예약시간을 삭제한다.")
     void deleteReservationTime() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("startAt", "10:00");
 
         예약시간을_생성한다(params);
@@ -124,7 +123,7 @@ public class ReservationTimeTest {
     @Test
     @DisplayName("예약시간을 삭제할 때 사용중인 예약이 있는 경우 에러가 발생한다.")
     void deleteReservationTimeExistReservation() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", "레벨2 탈출");
         params.put("description", "우테코 레벨2를 탈출하는 내용입니다.");
         params.put("thumbnail", "https://i.pinimg.com/236x/6e/bc/46/6ebc461a94a49f9ea3b8bbe2204145d4.jpg");
@@ -139,8 +138,8 @@ public class ReservationTimeTest {
         params.clear();
         params.put("name", "브라운");
         params.put("date", "2024-06-25");
-        params.put("timeId", "1");
-        params.put("themeId", "1");
+        params.put("timeId", 1L);
+        params.put("themeId", 1L);
         예약을_생성한다(params, token);
 
         RestAssured.given().log().all()
@@ -154,7 +153,7 @@ public class ReservationTimeTest {
     @DisplayName("테마의 예약가능 시간 목록을 조회한다.")
     @Test
     void availableTimes() {
-        Map<String, String> params = new HashMap<>();
+        Map<String, Object> params = new HashMap<>();
         params.put("name", "레벨2 탈출");
         params.put("description", "우테코 레벨2를 탈출하는 내용입니다.");
         params.put("thumbnail", "https://i.pinimg.com/236x/6e/bc/46/6ebc461a94a49f9ea3b8bbe2204145d4.jpg");
@@ -172,8 +171,8 @@ public class ReservationTimeTest {
         params.clear();
         params.put("name", "브라운");
         params.put("date", "2024-06-25");
-        params.put("timeId", "1");
-        params.put("themeId", "1");
+        params.put("timeId", 1L);
+        params.put("themeId", 1L);
         예약을_생성한다(params, token);
 
         RestAssured.given().log().all()

--- a/src/test/java/roomescape/controller/ReservationTimeTest.java
+++ b/src/test/java/roomescape/controller/ReservationTimeTest.java
@@ -1,6 +1,7 @@
 package roomescape.controller;
 
 import static org.hamcrest.Matchers.is;
+import static roomescape.fixture.AuthFixture.사용자_로그인;
 import static roomescape.fixture.ReservationFixture.예약을_생성한다;
 import static roomescape.fixture.ReservationThemeFixture.예약테마를_생성한다;
 import static roomescape.fixture.ReservationTimeFixture.예약시간을_생성한다;
@@ -10,6 +11,8 @@ import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,6 +23,16 @@ import org.springframework.test.annotation.DirtiesContext;
 @DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
 @DisplayName("예약시간 테스트")
 public class ReservationTimeTest {
+
+    private static final String EMAIL = "test@email.com";
+    private static final String PASSWORD = "1234";
+    private String token;
+
+    @BeforeEach
+    void init() {
+        Response response = 사용자_로그인(EMAIL, PASSWORD);
+        token = response.getCookie("token");
+    }
 
     @Test
     @DisplayName("예약시간을 생성한다.")
@@ -124,7 +137,7 @@ public class ReservationTimeTest {
         params.put("date", "2024-06-25");
         params.put("timeId", "1");
         params.put("themeId", "1");
-        예약을_생성한다(params);
+        예약을_생성한다(params, token);
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
@@ -157,7 +170,7 @@ public class ReservationTimeTest {
         params.put("date", "2024-06-25");
         params.put("timeId", "1");
         params.put("themeId", "1");
-        예약을_생성한다(params);
+        예약을_생성한다(params, token);
 
         RestAssured.given().log().all()
                 .contentType(ContentType.JSON)

--- a/src/test/java/roomescape/fixture/AuthFixture.java
+++ b/src/test/java/roomescape/fixture/AuthFixture.java
@@ -1,0 +1,18 @@
+package roomescape.fixture;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+import roomescape.dto.request.LoginRequest;
+
+public class AuthFixture {
+
+    public static Response 사용자_로그인(String email, String password) {
+        return RestAssured
+                .given().log().all()
+                .body(new LoginRequest(email, password))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/login");
+    }
+}

--- a/src/test/java/roomescape/fixture/MemberFixture.java
+++ b/src/test/java/roomescape/fixture/MemberFixture.java
@@ -1,0 +1,18 @@
+package roomescape.fixture;
+
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.springframework.http.MediaType;
+import roomescape.dto.request.MemberRequest;
+
+public class MemberFixture {
+
+    public static Response 회원가입(String email, String password, String name) {
+        return RestAssured
+                .given().log().all()
+                .body(new MemberRequest(name, email, password))
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().post("/members");
+    }
+}

--- a/src/test/java/roomescape/fixture/ReservationFixture.java
+++ b/src/test/java/roomescape/fixture/ReservationFixture.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class ReservationFixture {
 
-    public static Response 예약을_생성한다(Map<String, String> params, String token) {
+    public static Response 예약을_생성한다(Map<String, Object> params, String token) {
         return RestAssured.given().log().all()
                 .cookie("token", token)
                 .contentType(ContentType.JSON)
@@ -15,7 +15,7 @@ public class ReservationFixture {
                 .when().post("/reservations");
     }
 
-    public static Response 예약을_생성한다_관리자(Map<String, String> params, String token) {
+    public static Response 예약을_생성한다_관리자(Map<String, Object> params, String token) {
         return RestAssured.given().log().all()
                 .cookie("token", token)
                 .contentType(ContentType.JSON)

--- a/src/test/java/roomescape/fixture/ReservationFixture.java
+++ b/src/test/java/roomescape/fixture/ReservationFixture.java
@@ -14,4 +14,12 @@ public class ReservationFixture {
                 .body(params)
                 .when().post("/reservations");
     }
+
+    public static Response 예약을_생성한다_관리자(Map<String, String> params, String token) {
+        return RestAssured.given().log().all()
+                .cookie("token", token)
+                .contentType(ContentType.JSON)
+                .body(params)
+                .when().post("/admin/reservations");
+    }
 }

--- a/src/test/java/roomescape/fixture/ReservationFixture.java
+++ b/src/test/java/roomescape/fixture/ReservationFixture.java
@@ -7,8 +7,9 @@ import java.util.Map;
 
 public class ReservationFixture {
 
-    public static Response 예약을_생성한다(Map<String, String> params) {
+    public static Response 예약을_생성한다(Map<String, String> params, String token) {
         return RestAssured.given().log().all()
+                .cookie("token", token)
                 .contentType(ContentType.JSON)
                 .body(params)
                 .when().post("/reservations");

--- a/src/test/java/roomescape/fixture/ReservationThemeFixture.java
+++ b/src/test/java/roomescape/fixture/ReservationThemeFixture.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class ReservationThemeFixture {
 
-    public static Response 예약테마를_생성한다(Map<String, String> params) {
+    public static Response 예약테마를_생성한다(Map<String, Object> params) {
         return RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(params)

--- a/src/test/java/roomescape/fixture/ReservationTimeFixture.java
+++ b/src/test/java/roomescape/fixture/ReservationTimeFixture.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 public class ReservationTimeFixture {
 
-    public static Response 예약시간을_생성한다(Map<String, String> params) {
+    public static Response 예약시간을_생성한다(Map<String, Object> params) {
         return RestAssured.given().log().all()
                 .contentType(ContentType.JSON)
                 .body(params)


### PR DESCRIPTION
안녕하세요. 2단계 로그인 리팩터링 리뷰 요청 드립니다!

--- 
**고민했던 부분**

`HandlerMethodArgumentResolver`를 사용하면서 처음 구현했던 방식은 토큰에서 id(email)를 추출하고, `MemberService.findByEmail`로 가져온 사용자 정보로 `LoginMember` 값을 세팅 했습니다.
이후 LoginMember를 주입받는 모든 컨트롤러에서 사용자의 모든 정보를 필요로 하지 않는 경우 => 불필요한 조회로 DB I/O 발생한다고 생각되어 토큰에 세팅한 정보로만 구성하도록 수정했는데 올바른 방향인지 고민 됩니다.

만약 사용자 정보가 필요한 요청 중 추가 회원 정보가 필요한 경우라면 서비스 단에서 조회하도록 하면 좋을까요?